### PR TITLE
fix : config rewrite 수정

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -23,12 +23,14 @@ const nextConfig = {
       },
     ],
   },
-  rewrites: () => [
-    {
-      source: '/api/:path*',
-      destination: `${process.env.NEXT_PUBLIC_BACKEND_SERVER_API}/:path*`,
-    },
-  ],
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_BACKEND_SERVER_API}/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
- Vercel 정식 디플로이 후, Postman 요청 결과 성공적으로 반환
- Vercel 홈페이지 접근 시 403 오류 그대로 발생
- Wireshark 분석 결과, 프로덕션 모드에서는 네트워크 탭에서 프록시 작용으로 목적지를 확인할 수 없음
- Wireshark에서는 원본 서버 IP로 요청이 확인됨
- Vercel WHOIS 검색 결과 (76.76.21.0/24 확인) 패킷 분석 결과 76.76.21.0/24 대역으로 요청. HTTPS라 상세한 정보는 알 수 없지만 백엔드 서버 IP로의 요청하는 원본 패킷은 확인되지 않음
- 프록시가 작동하지 않는 것으로 판단하여 공식 페이지 확인 결과 async rewrite 수정 필요