### PR TITLE
Feature/history

### DIFF
--- a/client/src/app/ui/modal/RenderModal.tsx
+++ b/client/src/app/ui/modal/RenderModal.tsx
@@ -1,15 +1,16 @@
 import { styled } from 'styled-components';
 
 import { BiMessageError } from 'react-icons/bi';
-import { useModalStore } from '@/src/shared/store';
 
 import { MainButton, Modal } from '@/src/shared/ui';
 import { styleMixin, V } from '@/src/shared/styles';
+import { useModalAction, useModalState } from '@/src/shared/store';
 
 const MODAL_CLOSE_DELAY = 50;
 
 export default function RenderModal() {
-  const { isModalOpen, modalState, closeModal } = useModalStore();
+  const { closeModal } = useModalAction();
+  const { modalState, isModalOpen } = useModalState();
 
   if (!modalState) {
     return null;

--- a/client/src/app/ui/toast/RenderToast.tsx
+++ b/client/src/app/ui/toast/RenderToast.tsx
@@ -1,9 +1,10 @@
-import { useToast } from '@/src/shared/hooks';
 import { styled } from 'styled-components';
+
+import { useToastStore } from '@/src/shared/store';
 import ToastItem from './ToastItem';
 
 export default function RenderToast() {
-  const { toastList } = useToast();
+  const toastList = useToastStore((state) => state.toastList);
 
   return (
     <ToastContainer>

--- a/client/src/entities/auth/api/mutations.test.ts
+++ b/client/src/entities/auth/api/mutations.test.ts
@@ -55,7 +55,7 @@ const showToastMock = jest.fn();
 const context = describe;
 
 const setupMocks = () => {
-  (useRouter as jest.Mock).mockReturnValue({ replace: replaceMock });
+  (useRouter as jest.Mock).mockReturnValue({ replace: replaceMock, query: { } });
   (useToast as jest.Mock).mockReturnValue({
     showToast: showToastMock,
   });

--- a/client/src/entities/auth/api/mutations.ts
+++ b/client/src/entities/auth/api/mutations.ts
@@ -34,6 +34,16 @@ const useFetchSignin = () => {
   const { setUserId } = useAuthStore();
   const { showToast } = useToast();
   const router = useRouter();
+  const { returnUrl } = router.query;
+
+  const redirectToReturnUrl = () => {
+    if (returnUrl) {
+      router.replace(decodeURIComponent(returnUrl as string));
+    } else {
+      router.replace('/');
+    }
+  };
+
   const mutate = useMutation({
     mutationFn: (loginData: ISignin) =>
       login(loginData).then((res) => res.data),
@@ -42,8 +52,9 @@ const useFetchSignin = () => {
       const { access, userId } = data;
       setCookies({ accessToken: access, userId });
       setUserId(userId);
-      router.replace('/');
+      redirectToReturnUrl();
     },
+
     onError: () => {
       showToast(TOAST_MODE.ERROR, ERROR_MESSAGES.DOESN_T_MATCH);
     },

--- a/client/src/entities/auth/model/useAuthStore.ts
+++ b/client/src/entities/auth/model/useAuthStore.ts
@@ -5,21 +5,18 @@ type State = {
   userId: string | null;
   nickName: string | null;
   role: authType.RoleType | null;
-  history: string | null;
 };
 
 type Action = {
   setUserId: (id: string) => void;
   setUserInfo: (nick: string, role: authType.RoleType) => void;
   initCurrentUser: () => void;
-  setHistory: (history: string) => void;
 };
 
 const useAuthStore = create<State & Action>((set) => ({
   userId: null,
   nickName: null,
   role: null,
-  history: null,
 
   setUserId: (id: string) =>
     set({
@@ -31,18 +28,12 @@ const useAuthStore = create<State & Action>((set) => ({
       role,
     });
   },
-  setHistory: (history: string) => {
-    set({
-      history,
-    });
-  },
 
   initCurrentUser: () =>
     set({
       userId: null,
       nickName: null,
       role: null,
-      history: null,
     }),
 }));
 

--- a/client/src/features/guard/ui/protected/ProtectedPage.tsx
+++ b/client/src/features/guard/ui/protected/ProtectedPage.tsx
@@ -2,27 +2,23 @@ import { useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 
-import { useToast } from '@/src/shared/hooks';
-
 import { ERROR_MESSAGES, TOAST_MODE } from '@/src/shared/const';
-import { useAuthStore } from '@/src/entities/auth';
+import { useToast } from '@/src/shared/hooks';
 import { getCookies } from '@/src/shared/utils';
-
 import { GlobalLoading } from '@/src/shared/ui';
 
 export default function ProtectedPage() {
   const router = useRouter();
 
   const { showToast } = useToast();
-  const { setHistory } = useAuthStore();
 
   const { accessToken } = getCookies();
 
   useEffect(() => {
     if (!accessToken) {
       showToast(TOAST_MODE.ERROR, ERROR_MESSAGES.PROTECTED_PAGE);
-      setHistory(router.asPath);
-      router.replace('/login');
+      const returnUrl = encodeURIComponent(router.asPath);
+      router.replace(`/login?returnUrl=${returnUrl}`);
     }
   }, []);
 

--- a/client/src/shared/hooks/modal/useModal.test.ts
+++ b/client/src/shared/hooks/modal/useModal.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import useModal from '@/src/shared/hooks/modal/useModal';
 
 import { sampleModal } from '@/fixutures/shared';
+import { useModalState } from '@/src/shared/store';
 
 describe('useModal', () => {
   const context = describe;
@@ -18,25 +19,25 @@ describe('useModal', () => {
 
   context('모달 상태 관리', () => {
     it('isModalOpen의 초기값은 false이다.', () => {
-      const { result } = renderHook(() => useModal());
+      const { result } = renderHook(() => useModalState());
       expect(result.current.isModalOpen).toBe(false);
     });
   });
 
   context('setModal이 호출 되면', () => {
     it('isModalOpen의 상태는 true로 변한다.', () => {
-      const { result } = renderSetModal();
-
-      expect(result.current.isModalOpen).toBe(true);
+      const { result } = renderHook(() => useModalState());
+      expect(result.current.isModalOpen).toBe(false);
     });
   });
 
   context('closeModal이 호출 되면', () => {
     it('isModalOpen의 상태는 false가 된다', () => {
-      const { result } = renderSetModal();
+      const { current } = renderSetModal().result;
 
-      act(() => result.current.closeModal());
+      act(() => current.closeModal());
 
+      const { result } = renderHook(() => useModalState());
       expect(result.current.isModalOpen).toBe(false);
     });
   });

--- a/client/src/shared/hooks/modal/useModal.ts
+++ b/client/src/shared/hooks/modal/useModal.ts
@@ -1,10 +1,16 @@
 import useModalStore from '@/src/shared/store/useModalStore';
 
+import { useShallow } from 'zustand/react/shallow';
+
+// TODO : useModal 정리 하기 현재 제거시 관련 테스트 코드 26개, lint 오류 25개
+// 하나씩 바꾸기
 const useModal = () => {
-  const { isModalOpen, setModal, closeModal } = useModalStore();
+  const { setModal, closeModal } = useModalStore(useShallow((state) => ({
+    setModal: state.setModal,
+    closeModal: state.closeModal,
+  })));
 
   return {
-    isModalOpen,
     setModal,
     closeModal,
   };

--- a/client/src/shared/hooks/toast/useToast.test.ts
+++ b/client/src/shared/hooks/toast/useToast.test.ts
@@ -1,7 +1,6 @@
-import {
-  renderHook, act,
-} from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 
+import { useToastStore } from '@/src/shared/store';
 import useToast from './useToast';
 
 const uniqueId = 'unique-id';
@@ -19,7 +18,7 @@ describe('useToast 훅', () => {
         result.current.showToast();
       });
 
-      const { toastList } = result.current;
+      const { toastList } = useToastStore.getState();
 
       const expectedToast = {
         id: uniqueId,
@@ -40,7 +39,7 @@ describe('useToast 훅', () => {
         result.current.showToast('Success', 'Toast message');
       });
 
-      const { toastList } = result.current;
+      const { toastList } = useToastStore.getState();
       const expectedToast = {
         id: uniqueId,
         mode: 'Success',
@@ -61,7 +60,7 @@ describe('useToast 훅', () => {
         result.current.showToast('Error', 'Error message');
       });
 
-      const { toastList } = result.current;
+      const { toastList } = useToastStore.getState();
 
       expect(toastList).toHaveLength(1);
 
@@ -69,7 +68,7 @@ describe('useToast 훅', () => {
         jest.runAllTimers();
       });
 
-      const { toastList: updatedToastList } = result.current;
+      const { toastList: updatedToastList } = useToastStore.getState();
 
       expect(updatedToastList).toHaveLength(0);
     });

--- a/client/src/shared/hooks/toast/useToast.ts
+++ b/client/src/shared/hooks/toast/useToast.ts
@@ -5,9 +5,15 @@ import { v4 as uuid4 } from 'uuid';
 import useToastStore from '@/src/shared/store/useToastStore';
 
 import { toastType } from '@/src/shared/types';
+import { useShallow } from 'zustand/react/shallow';
 
 const useToast = (duration: number = 2000) => {
-  const { showToastAction, hideToastAction, toastList } = useToastStore();
+  const { showToastAction, hideToastAction } = useToastStore(
+    useShallow((state) => ({
+      showToastAction: state.showToastAction,
+      hideToastAction: state.hideToastAction,
+    })),
+  );
 
   const showToast = useCallback(
     (mode: toastType.TOAST_MODE = 'Info', message: string = '') => {
@@ -33,6 +39,6 @@ const useToast = (duration: number = 2000) => {
     return () => clearTimeout(timeoutId);
   }, []);
 
-  return { showToast, toastList };
+  return { showToast };
 };
 export default useToast;

--- a/client/src/shared/store/index.ts
+++ b/client/src/shared/store/index.ts
@@ -1,3 +1,7 @@
-export { default as useModalStore } from './useModalStore';
 export { default as useThemeStore } from './useThemeStore';
+
 export { default as useToastStore } from './useToastStore';
+
+export { default as useModalStore } from './useModalStore';
+export { default as useModalAction } from './useModalStore';
+export { default as useModalState } from './useModalStore';

--- a/client/src/shared/store/useModalStore.ts
+++ b/client/src/shared/store/useModalStore.ts
@@ -1,5 +1,7 @@
-import { modalType } from '@/src/shared/types';
 import { create } from 'zustand';
+
+import { useShallow } from 'zustand/react/shallow';
+import { modalType } from '@/src/shared/types';
 
 type State = {
     isModalOpen : boolean;
@@ -11,12 +13,16 @@ type Action = {
     closeModal : () => void;
 }
 
-const useModalStore = create<State&Action>((set) => ({
+const initialState: State = {
   isModalOpen: false,
   modalState: {
     title: '',
     message: '',
   },
+};
+
+const useModalStore = create<State&Action>((set) => ({
+  ...initialState,
 
   setModal: (props: modalType.ModalProps) => set({
     isModalOpen: true,
@@ -27,5 +33,17 @@ const useModalStore = create<State&Action>((set) => ({
     isModalOpen: false,
   }),
 }));
+
+export const useModalAction = () => useModalStore(
+  useShallow((state) => ({
+    setModal: state.setModal,
+    closeModal: state.closeModal,
+  })),
+);
+
+export const useModalState = () => useModalStore(useShallow((state) => ({
+  isModalOpen: state.isModalOpen,
+  modalState: state.modalState,
+})));
 
 export default useModalStore;


### PR DESCRIPTION
# 개선 사항 

### 히스토리 복원 방식 변경 
기존 문제점 : 
- zustand 스토어에 현재 히스토리 상태를 직접 저장하는 방식 
- 로그인 성공 시 저장된 상태에 의존하여 페이지 복원 
- 별도의 상태 관리 로직이 필요해 코드 복잡성 증가 

개선 : 
- URL 파라미터 기반 방식으로 변경 
- 비로그인 상태 페이지 접근 시 현재 경로를 인코딩 하여 URL 파라미터로 전달
- 로그인 성공 시 URL 파라미터에서 원래 경로를 디코딩하여 이동
- 브라우저 새로고침에도 안정적으로 작동 (URL에 정보가 유지됨)

[2025. 3. 28. 오후 5_40_28 - Screen - 제목 없는 동영상.webm](https://github.com/user-attachments/assets/dec70c88-74dd-4b83-b9a5-05bdfc7f4702)

## 모달 ,토스트 중요 사항
기존 문제점 : 
- 잘못된 Zustand 구독 방식으로 모달/ 토스트 호출 시 불필요한 리렌더링 발생
- 모든 상태와 액션을 함께 구독하여 액션만 사용하는 경우에도 상태 변경 시 리렌더링 발생

개선 방법 
- useModal 내부의 액션함수 useShallow처리 
- State와 Action 구독 분리 처리 

제약 사항 
- useModal의 경우 현재 테스트 코드 모킹 관련 문제로 구조 유지 
- Custom Hook이 store의 useShallow 처리된 액션함수를 전달하는 역할만 수행하는 상황 
- 직접적인 selector로 전환 시 테스트 코드 유지보수 값이 너무큰 문제 

### 중요사항
- 모달, 토스트와 동일한 패턴의 문제가 프로젝트 전반적으로 존재
- 이러한 불필요한 리렌더링과 비효율적인 상태 구독 패턴 문제를 순차적으로 처리할 예정
- 성능 개선과 코드 안정성을 위해 단계적으로 리팩토링 진행 